### PR TITLE
Upgrade build environment to Java 8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 script: ./gradlew clean check
-dist: precise
+dist: trusty
 jdk:
   - oraclejdk8
   - openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: java
 script: ./gradlew clean check
 dist: precise
 jdk:
-  - oraclejdk7
-  - openjdk7
+  - oraclejdk8
+  - openjdk8
 addons:
   hosts:
     - xgboosthost

--- a/build.gradle
+++ b/build.gradle
@@ -23,13 +23,13 @@ subprojects {
     group 'biz.k11i'
 
     compileJava {
-        sourceCompatibility = JavaVersion.VERSION_1_7
-        targetCompatibility = JavaVersion.VERSION_1_7
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     compileTestJava {
-        sourceCompatibility = JavaVersion.VERSION_1_7
-        targetCompatibility = JavaVersion.VERSION_1_7
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     javadoc {
@@ -93,8 +93,8 @@ subprojects {
     createReleaseTag.dependsOn bintrayUpload
 
     task checkJavaVersion << {
-        if (!JavaVersion.current().isJava7()) {
-            String message = "ERROR: Java 7 required but " +
+        if (!JavaVersion.current().isJava8()) {
+            String message = "ERROR: Java 8 required but " +
                     JavaVersion.current() +
                     " found. Change your JAVA_HOME environment variable."
             throw new IllegalStateException(message)


### PR DESCRIPTION
Java 7 updates are no longer available from Oracle without a support contract since July 2015, and it is now difficult to set up a Java 7 development environment.