### PR TITLE
Support reg:squarederror for objective function

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Xgboost-predictor-java is about **6,000 to 10,000 times faster than** xgboost4j 
     - "multi:softmax"
     - "multi:softprob"
     - "reg:linear"
+    - "reg:squarederror"
     - "rank:pairwise"
 - API
     - Predicts probability or classification

--- a/xgboost-predictor/src/main/java/biz/k11i/xgboost/learner/ObjFunction.java
+++ b/xgboost-predictor/src/main/java/biz/k11i/xgboost/learner/ObjFunction.java
@@ -20,6 +20,7 @@ public class ObjFunction implements Serializable {
         register("multi:softmax", new SoftmaxMultiClassObjClassify());
         register("multi:softprob", new SoftmaxMultiClassObjProb());
         register("reg:linear", new ObjFunction());
+        register("reg:squarederror", new ObjFunction());
         register("reg:logistic", new RegLossObjLogistic());
     }
 


### PR DESCRIPTION
`reg:linear` is now [deprecated](https://github.com/dmlc/xgboost/pull/4267) and replace with `reg:squarederror` from [v0.90 release](https://github.com/dmlc/xgboost/pull/4475).

So, better to support a model built with `reg:squarederror`.
